### PR TITLE
Add support for DBF file encoding 

### DIFF
--- a/src/map.view.ts
+++ b/src/map.view.ts
@@ -417,9 +417,13 @@ export class MapView {
             await fileUtils.readDataFile(dataUrl.replace('.shp', '.prj'), 'utf8');
           const dbfData = 
             await fileUtils.readDataFile(dataUrl.replace('.shp', '.dbf'), null);
+          const cpgFilePath = dataUrl.replace('.shp', '.cpg');
+          const encoding = fs.existsSync(cpgFilePath)
+            ? await fileUtils.readDataFile(cpgFilePath, 'utf8')
+            : undefined;
           this._mapData = shapefile.combine([
               shapefile.parseShp(shapefileData, prjData),
-              shapefile.parseDbf(dbfData)
+              shapefile.parseDbf(dbfData, encoding)
             ]);
             this.createGeoJsonFile(this._mapData);
             this.refreshMapView();


### PR DESCRIPTION
Awesome extension — thanks for making it!

I had issues with some Scandinavian characters, which can be fixed by including the encoding as the second argument in the DBF parser. According to the spec[0] a `.cpg` file can specify the encoding, so this pull request adds support for that.

[0] Well, [Wikipedia](https://en.wikipedia.org/wiki/Shapefile#Overview) (see Other files), as well as [shapefile-js](https://github.com/calvinmetcalf/shapefile-js/blob/master/lib/index.js#L153) and [parseDBF](https://github.com/calvinmetcalf/parseDBF/blob/master/decoder.js#L9).